### PR TITLE
fix: bug in the dfs logic

### DIFF
--- a/src/app/services/item_service.py
+++ b/src/app/services/item_service.py
@@ -228,7 +228,7 @@ def get_item_by_id_dfs_iterative(
 
                     for task in lab.tasks:
                         counter += 1
-                        if lab.id == item_id:
+                        if task.id == item_id:
                             return FoundItem(task, counter)
 
                         for step in task.steps:


### PR DESCRIPTION
## Summary

- Fixed bug in `get_item_by_id_dfs_iterative` where `lab.id` was compared instead of `task.id`
- This caused the endpoint `/items/item/{task_id}` to return 404 for all task items

- Closes #3